### PR TITLE
feat | Turbo Drive - loading next five popular tracks

### DIFF
--- a/app/controllers/artists_controller.rb
+++ b/app/controllers/artists_controller.rb
@@ -1,13 +1,18 @@
 class ArtistsController < ApplicationController
   def show
+    limit = params[:limit].present? ? params[:limit].to_i : 5
     artist = Artist.find(params[:id])
     albums = selected_albums(artist.albums, params[:album_type]).with_attached_cover.preload(:artist)
-    tracks = artist.tracks.popularity_ordered.limit(5)
+    tracks = artist.tracks.popularity_ordered.limit(limit)
+    next_track_exists = artist.tracks.popularity_ordered.count > limit
 
     if turbo_frame_request?
-      render partial: "discography", locals: {artist:, albums:}
+      case turbo_frame_request_id
+      when /discography/ then render partial: "discography", locals: {artist:, albums:, next_track_exists:}
+      when /tracks/ then render partial: "popular_tracks", locals: {artist:, tracks:, limit:, next_track_exists:}
+      end
     else
-      render action: :show, locals: {artist:, albums:, tracks:}
+      render action: :show, locals: {artist:, albums:, tracks:, next_track_exists:}
     end
   end
 

--- a/app/controllers/artists_controller.rb
+++ b/app/controllers/artists_controller.rb
@@ -12,7 +12,7 @@ class ArtistsController < ApplicationController
       when /tracks/ then render partial: "popular_tracks", locals: {artist:, tracks:, limit:, next_track_exists:}
       end
     else
-      render action: :show, locals: {artist:, albums:, tracks:, next_track_exists:}
+      render action: :show, locals: {artist:, albums:, tracks:, limit:, next_track_exists:}
     end
   end
 

--- a/app/views/artists/_popular_tracks.html.erb
+++ b/app/views/artists/_popular_tracks.html.erb
@@ -1,0 +1,15 @@
+<%# locals: (artist:, tracks:, limit: 5, next_track_exists:) -%>
+<%= turbo_frame_tag dom_id(artist, :tracks), target: "_top" do %>
+  <h2 class="mt-4 text-header-2">Popular</h2>
+  <ul class="tracks mt-2">
+    <%= render tracks, enqueueble: true %>
+    <%- if next_track_exists %>
+      <li class="track">
+        <span class="track--number"></span>
+        <%= link_to "Load more", artist_path(limit: limit + 5),
+                    data: {"turbo-frame" => "_self", "turbo-action" => "advance"},
+                    class: "text-secondary hover:text-primary transition-colors" %>
+      </li>
+    <% end %>
+  </ul>
+<% end %>

--- a/app/views/artists/show.html.erb
+++ b/app/views/artists/show.html.erb
@@ -18,14 +18,7 @@
 
 <hr class="my-4">
 
-<h2 class="mt-4 text-header-2">Popular</h2>
-<ul class="tracks mt-2">
-  <%= render tracks, enqueueble: true %>
-  <li class="track">
-    <span class="track--number"></span>
-    <a href="#" class="text-secondary hover:text-primary transition-colors">Load more</a>
-  </li>
-</ul>
+<%= render partial: "popular_tracks", locals: {artist:, tracks:, next_track_exists:} %>
 
 <hr class="my-4"/>
 

--- a/app/views/artists/show.html.erb
+++ b/app/views/artists/show.html.erb
@@ -18,7 +18,7 @@
 
 <hr class="my-4">
 
-<%= render partial: "popular_tracks", locals: {artist:, tracks:, next_track_exists:} %>
+<%= render partial: "popular_tracks", locals: {artist:, tracks:, limit:, next_track_exists:} %>
 
 <hr class="my-4"/>
 


### PR DESCRIPTION
This PR aims to implement loading more popular tracks for a given artist.
We want to load the next five popular tracks each time a user clicks on the `Load more` link on the Artist page.

## Context

Currently, users can see only the five most popular tracks for each artist. We want to allow them to load more popular tracks.

## Solution

I decided to wrap  the**popular tracks** section in a turbo frame and re-render the whole section each time user clicks on the `Load more` link. Each time the link is clicked, we increase the amount of tracks, loaded on the page by five.