### PR TITLE
feat |  Turbo Drive infinite scroll implementation

### DIFF
--- a/app/assets/stylesheets/artist.css
+++ b/app/assets/stylesheets/artist.css
@@ -17,3 +17,15 @@
 .artist-meta {
   @apply mt-2;
 }
+
+.tracks-navigation-container {
+  @apply flex flex-row justify-between
+}
+
+.tracks-navigation-container .nav-link-container {
+  @apply flex flex-col-reverse
+}
+
+.nav-link-container .nav-link {
+  @apply text-secondary hover:text-primary transition-colors text-small
+}

--- a/app/controllers/tracks_controller.rb
+++ b/app/controllers/tracks_controller.rb
@@ -1,4 +1,14 @@
 class TracksController < ApplicationController
+  def index
+    page_size = 50
+    artist = Artist.find(params[:artist_id])
+    page = params[:page].to_i
+    tracks = artist.tracks.popularity_ordered.limit(page_size).offset(page_size * page)
+    next_page = page + 1 if tracks.count >= page_size
+
+    render locals: {artist:, tracks:, page:, next_page:, page_size:}
+  end
+
   def play
     track = Track.find(params[:id])
 

--- a/app/views/artists/show.html.erb
+++ b/app/views/artists/show.html.erb
@@ -18,7 +18,13 @@
 
 <hr class="my-4">
 
-<h2 class="mt-4 text-header-2">Popular</h2>
+<div class="flex flex-row justify-between">
+  <h2 class="mt-4 text-header-2">Popular</h2>
+  <div class="flex flex-col-reverse">
+    <%= link_to 'See all', artist_tracks_path(artist, page: 0),
+                class: "text-secondary hover:text-primary transition-colors" %>
+  </div>
+</div>
 <ul class="tracks mt-2">
   <%= render tracks, enqueueble: true %>
   <li class="track">

--- a/app/views/artists/show.html.erb
+++ b/app/views/artists/show.html.erb
@@ -18,11 +18,10 @@
 
 <hr class="my-4">
 
-<div class="flex flex-row justify-between">
+<div class="tracks-navigation-container">
   <h2 class="mt-4 text-header-2">Popular</h2>
-  <div class="flex flex-col-reverse">
-    <%= link_to 'See all', artist_tracks_path(artist, page: 0),
-                class: "text-secondary hover:text-primary transition-colors" %>
+  <div class="nav-link-container">
+    <%= link_to 'See all', artist_tracks_path(artist, page: 0), class: "nav-link" %>
   </div>
 </div>
 <ul class="tracks mt-2">

--- a/app/views/tracks/_load_next_page.html.erb
+++ b/app/views/tracks/_load_next_page.html.erb
@@ -1,1 +1,1 @@
-<%= turbo_frame_tag "tracks_page_#{page}", src: artist_tracks_path(artist, page: page) %>
+<%= turbo_frame_tag "tracks_page_#{page}", src: artist_tracks_path(artist, page: page), loading: :lazy %>

--- a/app/views/tracks/_load_next_page.html.erb
+++ b/app/views/tracks/_load_next_page.html.erb
@@ -1,0 +1,1 @@
+<%= turbo_frame_tag "tracks_page_#{page}", src: artist_tracks_path(artist, page: page) %>

--- a/app/views/tracks/index.html.erb
+++ b/app/views/tracks/index.html.erb
@@ -1,0 +1,20 @@
+<div class="artist-header">
+  <div class="artist-image">
+    <% if artist.cover.attached? %>
+      <%= image_tag artist.cover %>
+    <% end %>
+  </div>
+  <div class="artist-info">
+    <div class="flex items-center">
+      <h1 class="text-header-2"><%= artist.name %></h1>
+    </div>
+    <div>
+      <% artist.tags.each do |tag| %>
+        <span class="meta"><%= tag %></span>
+      <% end %>
+    </div>
+  </div>
+</div>
+
+<h2 class="mt-4 text-header-2">Tracks</h2>
+<%= render tracks %>

--- a/app/views/tracks/index.html.erb
+++ b/app/views/tracks/index.html.erb
@@ -17,4 +17,13 @@
 </div>
 
 <h2 class="mt-4 text-header-2">Tracks</h2>
-<%= render tracks %>
+
+<%= turbo_frame_tag "tracks_page_#{page}" do %>
+  <% tracks.each_with_index do |track, i| %>
+    <%= render track, track_counter: page * page_size + i, enqueueble: true %>
+  <% end %>
+
+  <% if next_page %>
+    <%= render partial: 'tracks/load_next_page', locals: {page: next_page, artist: artist} %>
+  <% end %>
+<% end %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -5,7 +5,9 @@ Rails.application.routes.draw do
   post "sign_up", to: "registrations#create"
   delete "sign_out", to: "sessions#destroy", as: :sign_out
 
-  resources :artists, only: [:show]
+  resources :artists, only: [:show] do
+    resources :tracks, only: [:index]
+  end
   resources :albums, only: [:show] do
     patch :play, on: :member
   end


### PR DESCRIPTION
This PR aims to implement infinite scroll using Turbo Drive.

## Context

We want to be able to show all tracks of a given artist to the user. However, there might be too many tracks and we want to avoid overloading the server (or maybe even the client) with too many requests.
For this purpose, we will load tracks lazily when the user scrolls down to the end of currently loaded tracks.

## Implementation details

For lazy loading, we will implement infinite scroll for tracks.
To do this, we will load the first 50 tracks upon user request and then load the next 50 tracks once the user scrolls down to the end of the tracklist. 
We will use simple `offset-limit` pagination for this and we will use [turbo frames lazy loading](https://turbo.hotwired.dev/reference/frames#lazy-loaded-frame) for new tracks rendering.