### PR TITLE
feat | Close flash by clicking on cross icon

### DIFF
--- a/app/assets/stylesheets/flash.css
+++ b/app/assets/stylesheets/flash.css
@@ -1,6 +1,6 @@
 @layer components {
   .flash {
-    @apply max-w-sm bg-white opacity-95 border-t-4 border-slate-900 rounded-b text-black px-4 py-3 shadow-md;
+    @apply max-w-sm bg-white opacity-95 border-t-4 border-slate-900 rounded-b text-black px-4 py-3 shadow-md relative;
   }
 
   .flash.notice {
@@ -9,5 +9,13 @@
 
   .flash.alert {
     @apply border-red-800 text-red-800;
+  }
+
+  .flash-container {
+    @apply flex flex-row;
+  }
+
+  .flash--close-button > svg {
+    @apply absolute w-3.5 h-3.5 top-0 right-0
   }
 }

--- a/app/views/layouts/_flash.html.erb
+++ b/app/views/layouts/_flash.html.erb
@@ -3,13 +3,27 @@
   <div class="flex justify-center">
     <% if flash[:notice] %>
       <div class="flash notice" role="alert" data-turbo-temporary data-controller="removeable" data-removeable-after-value="5">
-        <p class="text-small"><%= flash[:notice] %></p>
+        <div class="flash-container">
+          <p class="text-small"><%= flash[:notice] %></p>
+          <button class="flash--close-button" data-action="click->removeable#remove">
+            <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="w-6 h-6">
+              <path stroke-linecap="round" stroke-linejoin="round" d="M6 18L18 6M6 6l12 12" />
+            </svg>
+          </button>
+        </div>
       </div>
     <% end %>
 
     <% if flash[:alert] %>
       <div class="flash alert" role="alert" data-turbo-temporary data-controller="removeable" data-removeable-after-value="5">
-        <p class="text-small"><%= flash[:alert] %></p>
+        <div class="flash-container">
+          <p class="text-small"><%= flash[:alert] %></p>
+          <button class="flash--close-button" data-action="click->removeable#remove">
+            <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="w-6 h-6">
+              <path stroke-linecap="round" stroke-linejoin="round" d="M6 18L18 6M6 6l12 12" />
+            </svg>
+          </button>
+        </div>
       </div>
     <% end %>
   </div>

--- a/app/views/shared/_nav.html.erb
+++ b/app/views/shared/_nav.html.erb
@@ -25,7 +25,7 @@
     <%- if current_user -%>
       <span class="nav--username"><%= User::PREFIX + current_user.username %></span>
       <%= button_to "Sign out", sign_out_path, method: :delete, class: "nav--btn--outlined ml-2" %>
-    <%- else- %>
+    <%- else -%>
       <%= link_to "Sign up", sign_up_path, class: "nav--btn--outlined" %>
       <%= link_to "Log in", sign_in_path, class: "nav--btn ml-2" %>
     <%- end -%>


### PR DESCRIPTION
This PR aims to close flash messages upon clicking on the cross icon.

## Context

Currently, we close flash messages after a 10-second delay. However, users might want to close them earlier. We will add a cross icon, clicking on which will close the flash message.

## Implementation details

We already have a Stimulus `removeable` controller. We can reuse the `remove()` function to remove the flash message when the user clicks on the `cross` icon on the message.