### PR TITLE
feat | Toggle password field visibility

### DIFF
--- a/app/assets/stylesheets/login.css
+++ b/app/assets/stylesheets/login.css
@@ -16,3 +16,12 @@
   background-size: contain;
   background-position: center;
 }
+
+.login-form--password-field {
+  @apply flex flex-row justify-between relative;
+}
+
+.login-form--password-visibility-toggle svg {
+  @apply absolute right-1 bottom-1;
+  color: #949494;
+}

--- a/app/javascript/controllers/index.js
+++ b/app/javascript/controllers/index.js
@@ -1,6 +1,8 @@
 import { Application } from "@hotwired/stimulus";
+import PasswordVisibility from 'stimulus-password-visibility'
 
 const application = Application.start();
+application.register('password-visibility', PasswordVisibility)
 
 // Configure Stimulus development experience
 application.debug = document.documentElement.classList.contains("debug");

--- a/app/views/sessions/new.html.erb
+++ b/app/views/sessions/new.html.erb
@@ -8,7 +8,29 @@
       <h2 class="text-header-2 text-center">Welcome back!</h2>
       <%= form_with(url: sign_in_path) do |f| %>
         <%= f.text_field :username, value: params[:username_hint], require: true, autofocus: true, autocomplete: "username", class: "input mt-2", placeholder: "Username" %>
-        <%= f.password_field :password, required: true, autocomplete: "current-password", class: "input mt-2", placeholder: "*****" %>
+        <div class="login-form--password-field" data-controller="password-visibility">
+          <%= f.password_field :password,
+                               required: true,
+                               autocomplete: "current-password",
+                               class: "input mt-2",
+                               placeholder: "Password",
+                               "data-password-visibility-target" => "input", "spellcheck" => false %>
+
+          <button class="login-form--password-visibility-toggle" type="button" data-action="password-visibility#toggle">
+            <span data-password-visibility-target="icon">
+              <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="w-6 h-6">
+                <path stroke-linecap="round" stroke-linejoin="round" d="M2.036 12.322a1.012 1.012 0 010-.639C3.423 7.51 7.36 4.5 12 4.5c4.638 0 8.573 3.007 9.963 7.178.07.207.07.431 0 .639C20.577 16.49 16.64 19.5 12 19.5c-4.638 0-8.573-3.007-9.963-7.178z" />
+                <path stroke-linecap="round" stroke-linejoin="round" d="M15 12a3 3 0 11-6 0 3 3 0 016 0z" />
+              </svg>
+            </span>
+            <span data-password-visibility-target="icon" class="hidden">
+              <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="w-6 h-6">
+                <path stroke-linecap="round" stroke-linejoin="round" d="M3.98 8.223A10.477 10.477 0 001.934 12C3.226 16.338 7.244 19.5 12 19.5c.993 0 1.953-.138 2.863-.395M6.228 6.228A10.45 10.45 0 0112 4.5c4.756 0 8.773 3.162 10.065 7.498a10.523 10.523 0 01-4.293 5.774M6.228 6.228L3 3m3.228 3.228l3.65 3.65m7.894 7.894L21 21m-3.228-3.228l-3.65-3.65m0 0a3 3 0 10-4.243-4.243m4.242 4.242L9.88 9.88" />
+              </svg>
+            </span>
+          </button>
+        </div>
+
         <div class="flex flex-row justify-between items-baseline">
           <%= f.submit "Log in", class: "button button-primary mt-2" %>
           <%= link_to "Sign up", sign_up_path, class: "text-small opacity-50 hover:opacity-100" %>

--- a/config/importmap.rb
+++ b/config/importmap.rb
@@ -9,4 +9,5 @@ pin "turbo-morphdom", to: "turbo-morphdom.js"
 pin "fake_audio", to: "fake_audio.js"
 pin "@hotwired/stimulus", to: "https://ga.jspm.io/npm:@hotwired/stimulus@3.2.1/dist/stimulus.js"
 pin "@hotwired/stimulus-loading", to: "stimulus-loading.js", preload: true
+pin "stimulus-password-visibility", to: "https://ga.jspm.io/npm:stimulus-password-visibility@2.1.1/dist/stimulus-password-visibility.mjs"
 pin_all_from "app/javascript/controllers", under: "controllers"


### PR DESCRIPTION
This PR aims to add the ability to toggle password visibility on the login page.

## Context

Currently, the password is always hidden for the user. Complicated passwords are prone to errors and users sometimes want to check the typed password to check it for any potential errors.
We want to add a button to be able to toggle password visibility.

## Implementation details

We will use [Stimulus password visibility](https://www.stimulus-components.com/docs/stimulus-password-visibility/) component.