### PR TITLE
feat | Add play and pause hotkeys for player

### DIFF
--- a/app/javascript/controllers/player_controller.js
+++ b/app/javascript/controllers/player_controller.js
@@ -1,4 +1,5 @@
 import { Controller } from "@hotwired/stimulus";
+import { useHotkeys } from "stimulus-use/hotkeys"
 import FakeAudio from "fake_audio";
 
 function secondsToDuration(num) {
@@ -48,12 +49,31 @@ export default class extends Controller {
     if (this.playing) {
       this.play();
     }
+
+    useHotkeys(this, {
+      hotkeys: {
+        'space': {
+          handler: this.togglePlay
+        }
+      }
+    })
   }
 
   disconnect() {
     if (this.audio) {
       this.removeAudioListeners();
     }
+  }
+
+  togglePlay(e) {
+    e.preventDefault();
+
+    if (this.element.classList.contains(this.playingClass)) {
+      this.pause();
+      return
+    }
+
+    this.play();
   }
 
   play() {

--- a/config/importmap.rb
+++ b/config/importmap.rb
@@ -9,4 +9,6 @@ pin "turbo-morphdom", to: "turbo-morphdom.js"
 pin "fake_audio", to: "fake_audio.js"
 pin "@hotwired/stimulus", to: "https://ga.jspm.io/npm:@hotwired/stimulus@3.2.1/dist/stimulus.js"
 pin "@hotwired/stimulus-loading", to: "stimulus-loading.js", preload: true
+pin "stimulus-use/hotkeys", to: "https://ga.jspm.io/npm:stimulus-use@0.52.0/dist/hotkeys.js"
+pin "hotkeys-js", to: "https://ga.jspm.io/npm:hotkeys-js@3.11.2/dist/hotkeys.esm.js"
 pin_all_from "app/javascript/controllers", under: "controllers"


### PR DESCRIPTION
This PR aims to introduce hotkeys for pausing/resuming track play.

## Context

It's common to use hotkeys for managing some parts of the application state. In our case, a user might want to pause the track and resume it w/o using the mouse.
We want to introduce this ability by allowing users to use the spacebar for pausing/resuming track playthroughs.

## Implementation details

We will use [useHotkeys](https://stimulus-use.github.io/stimulus-use/#/use-hotkeys) JS library for managing hotkeys. For changing the state of the player we will use already implemented `pause()` and `play()` functions in the Stimulus `Player` controller.