### PR TITLE
feat | Improve search UX

### DIFF
--- a/app/assets/stylesheets/nav.css
+++ b/app/assets/stylesheets/nav.css
@@ -28,6 +28,22 @@
   @apply pl-10 p-1 w-full rounded border-none bg-opacity-0 bg-white transition-colors focus:bg-opacity-90 focus:border focus:border-gray-300 focus:outline-none outline-offset-0 !important;
 }
 
+.nav--search--input:has(+ .nav--search--results) {
+  @apply bg-opacity-90 border border-gray-300;
+}
+
+.nav--search {
+  @apply bg-opacity-90;
+}
+
+.nav--search--results {
+  @apply absolute w-[300px] top-0 bg-white mt-8 z-40 shadow-md pt-2;
+}
+
+.nav--search--result {
+  @apply p-2;
+}
+
 .nav--logo {
   @apply flex h-full items-center self-start;
   background: url("/assets/logo.png") no-repeat;

--- a/app/controllers/search_controller.rb
+++ b/app/controllers/search_controller.rb
@@ -2,6 +2,20 @@ class SearchController < ApplicationController
   def index
     q = params[:q]
 
+    @artists ||= []
+    @albums ||= []
+    @tracks ||= []
+
+    if turbo_frame_request?
+      if q.present? && q.length >= 3
+        @artists = Artist.search(q).limit(10)
+        @albums = Album.search(q).limit(10)
+        @tracks = Track.search(q).limit(10)
+      end
+
+      return render partial: "search/search_results"
+    end
+
     if q.blank? || q.length < 3
       return redirect_back(fallback_location: root_path, alert: "Please, enter at least 3 characters")
     end

--- a/app/javascript/controllers/searchable_controller.js
+++ b/app/javascript/controllers/searchable_controller.js
@@ -1,16 +1,23 @@
 import { Controller } from "@hotwired/stimulus";
+import { useDebounce } from 'stimulus-use'
 
 // Connects to data-controller="searchable"
 
 export default class extends Controller {
     static values = { url: String }
     static targets = ["query"]
+    static debounces = ["search"]
 
     initialize() {
         this.queryString = this.queryTarget.value
     }
 
-    search(e) {
+    connect() {
+        this.element.children.search_result.classList.remove('hidden')
+        useDebounce(this)
+    }
+
+    collectQuery(e) {
         if (e.key === 'Escape') {
             this.queryString = ""
         }
@@ -20,8 +27,7 @@ export default class extends Controller {
         }
 
         if (this.queryString.length >= 3) {
-            this.element.children.search_result.classList.remove('hidden')
-            Turbo.visit(this.urlValue + `?q=${this.queryString}`, { frame: 'search_result'})
+            this.search()
         }
 
         if (!e.key.match(/^\w$/)) {
@@ -29,6 +35,11 @@ export default class extends Controller {
         }
 
         this.queryString += e.key;
+    }
+
+    search(e) {
+        this.element.children.search_result.classList.remove('hidden')
+        Turbo.visit(this.urlValue + `?q=${this.queryString}`, { frame: 'search_result'})
     }
 
     clear() {

--- a/app/javascript/controllers/searchable_controller.js
+++ b/app/javascript/controllers/searchable_controller.js
@@ -1,0 +1,40 @@
+import { Controller } from "@hotwired/stimulus";
+
+// Connects to data-controller="searchable"
+
+export default class extends Controller {
+    static values = { url: String }
+    static targets = ["query"]
+
+    initialize() {
+        this.queryString = this.queryTarget.value
+    }
+
+    search(e) {
+        if (e.key === 'Escape') {
+            this.queryString = ""
+        }
+
+        if (e.key === 'Backspace') {
+            this.queryString = this.queryString.slice(0, -1)
+        }
+
+        if (this.queryString.length >= 3) {
+            this.element.children.search_result.classList.remove('hidden')
+            Turbo.visit(this.urlValue + `?q=${this.queryString}`, { frame: 'search_result'})
+        }
+
+        if (!e.key.match(/^\w$/)) {
+            return
+        }
+
+        this.queryString += e.key;
+    }
+
+    clear() {
+        this.queryString = ""
+        this.queryTarget.value = ""
+        Turbo.visit(this.urlValue, { frame: 'search_result' })
+        this.element.children.search_result.classList.add('hidden')
+    }
+}

--- a/app/views/search/_search_results.html.erb
+++ b/app/views/search/_search_results.html.erb
@@ -1,0 +1,32 @@
+<%= turbo_frame_tag :search_result, target: "_top" do %>
+  <%- if @artists.present? || @albums.present? || @tracks.present? %>
+    <ul class="nav--search--results">
+      <% if @artists.any? %>
+        <%- @artists.first(2).each do |artist| %>
+          <li class="nav--search--result">
+              <%= link_to artist.name, artist_path(artist), class: "hover:text-secondary", target: "_self" %>
+          </li>
+        <% end %>
+      <% end %>
+
+      <% if @albums.any? %>
+        <%- @albums.first(2).each do |album| %>
+          <li class="nav--search--result">
+            <%= link_to album.title, album_path(album), class: "hover:text-secondary", target: "_self" %>
+          </li>
+        <% end %>
+      <% end %>
+
+      <% if @tracks.any? %>
+        <%- @tracks.first(3).each do |track| %>
+          <li class="nav--search--result">
+            <%= link_to track.title, play_track_path(track),
+                        class: "hover:text-secondary",
+                        data: {"turbo-frame" => "player", "action" => "click->searchable#clear"} %>
+            <span class="ml-2 text-primary text-xsmall"><%= track.album.title %></span>
+          </li>
+        <% end %>
+      <% end %>
+    </ul>
+  <% end %>
+<% end %>

--- a/app/views/shared/_nav.html.erb
+++ b/app/views/shared/_nav.html.erb
@@ -14,12 +14,17 @@
         <% end %>
       <% end %>
     <%- end -%>
-    <%= form_with(url: search_path, method: :get, class: "nav--search") do |f| %>
-      <div class="nav--search--icon">
-        <%= render "icons/search" %>
-      </div>
-      <%= f.search_field :q, value: params[:q], class: "nav--search--input" %>
-    <% end %>
+    <div class="nav--search" data-controller="searchable" data-searchable-url-value="<%= search_path %>">
+      <%= form_with(url: search_path, method: :get, class: "nav--search") do |f| %>
+        <div class="nav--search--icon">
+          <%= render "icons/search" %>
+        </div>
+        <%= f.search_field :q, value: params[:q], class: "nav--search--input",
+                             "data-action" => "keydown->searchable#search",
+                             "data-searchable-target" => "query" %>
+      <% end %>
+      <%= turbo_frame_tag :search_result %>
+    </div>
   </div>
   <div class="nav--right">
     <%- if current_user -%>

--- a/app/views/shared/_nav.html.erb
+++ b/app/views/shared/_nav.html.erb
@@ -30,7 +30,7 @@
     <%- if current_user -%>
       <span class="nav--username"><%= User::PREFIX + current_user.username %></span>
       <%= button_to "Sign out", sign_out_path, method: :delete, class: "nav--btn--outlined ml-2" %>
-    <%- else- %>
+    <%- else -%>
       <%= link_to "Sign up", sign_up_path, class: "nav--btn--outlined" %>
       <%= link_to "Log in", sign_in_path, class: "nav--btn ml-2" %>
     <%- end -%>

--- a/app/views/shared/_nav.html.erb
+++ b/app/views/shared/_nav.html.erb
@@ -20,7 +20,7 @@
           <%= render "icons/search" %>
         </div>
         <%= f.search_field :q, value: params[:q], class: "nav--search--input",
-                             "data-action" => "keydown->searchable#search",
+                             "data-action" => "keydown->searchable#collectQuery",
                              "data-searchable-target" => "query" %>
       <% end %>
       <%= turbo_frame_tag :search_result %>

--- a/config/importmap.rb
+++ b/config/importmap.rb
@@ -9,4 +9,5 @@ pin "turbo-morphdom", to: "turbo-morphdom.js"
 pin "fake_audio", to: "fake_audio.js"
 pin "@hotwired/stimulus", to: "https://ga.jspm.io/npm:@hotwired/stimulus@3.2.1/dist/stimulus.js"
 pin "@hotwired/stimulus-loading", to: "stimulus-loading.js", preload: true
+pin "stimulus-use", to: "https://ga.jspm.io/npm:stimulus-use@0.52.0/dist/index.js"
 pin_all_from "app/javascript/controllers", under: "controllers"


### PR DESCRIPTION
This PR aims to improve search UX by adding a context window with the quick search result.

## Context

To improve UX we can immediately show search results in a small window while the user is typing a search query. 

## Implementation details

I've created Stimulus Controller for search query interactions and used turbo frames to show search results.
I also used `useDebounce` provided by `stimulus-use` to avoid flooding the server with unnecessary requests.